### PR TITLE
feat(db): env-gated SSL for pooler cutover

### DIFF
--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -342,6 +342,14 @@ export default buildConfig({
     push: process.env.PAYLOAD_SKIP_PUSH === 'true' ? false : undefined,
     pool: {
       connectionString: process.env.DATABASE_URI || process.env.DATABASE_URL || '',
+      // SSL for the PgBouncer pooler cutover. Gated on DATABASE_SSL so this is a NO-OP
+      // until that env var is set → safe to merge ahead of the cutover. The pooler
+      // terminates TLS with a SELF-SIGNED cert (CN=74.208.87.243, :6432), which
+      // node-postgres rejects by default; rejectUnauthorized:false is correct here —
+      // the cert is self-signed and the only public leg is Vercel→pooler (the
+      // pooler→Postgres hop is loopback on the same box). At cutover IONOS flips
+      // DATABASE_URI→:6432 and DATABASE_SSL=require together.
+      ssl: process.env.DATABASE_SSL === 'require' ? { rejectUnauthorized: false } : undefined,
       // Drizzle schema introspection fires many concurrent queries at startup.
       // Remote PostgreSQL needs more headroom than a local DB.
       // ⚠️ This repo deploys to MANY Vercel projects (angels-os, the-angel-os, spaces,


### PR DESCRIPTION
## What
Adds an env-gated `ssl` option to the Payload Postgres pool (`src/payload.config.ts`) so Vercel can connect to the new **PgBouncer pooler** (TLS terminated with a self-signed cert, CN=74.208.87.243, port 6432).

```ts
ssl: process.env.DATABASE_SSL === 'require' ? { rejectUnauthorized: false } : undefined,
```

## Why it's safe to merge now
- **Gated on `DATABASE_SSL`** → resolves to `undefined` until that env var is set. **No-op in prod and local dev** until cutover.
- No existing `ssl` key was overridden (confirmed).
- `rejectUnauthorized: false` is correct: the cert is self-signed and the only public leg is **Vercel → pooler**; the **pooler → Postgres** hop is loopback on the same box.
- TypeScript strict `tsc --noEmit` passes clean.

## Cutover (handled on the IONOS side, NOT in this PR)
IONOS flips `DATABASE_URI` → `:6432` and sets `DATABASE_SSL=require` **together**, after the pooler is live. **No Vercel env vars touched by this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)